### PR TITLE
Support validating base types of input types

### DIFF
--- a/src/Tests/Arguments/DerivedComplexInput.cs
+++ b/src/Tests/Arguments/DerivedComplexInput.cs
@@ -1,0 +1,4 @@
+﻿public class DerivedComplexInput : ComplexInput
+{
+    public string? SomeProperty { get; set; }
+}

--- a/src/Tests/Arguments/DerivedComplexInputGraph.cs
+++ b/src/Tests/Arguments/DerivedComplexInputGraph.cs
@@ -1,0 +1,14 @@
+﻿using GraphQL.Types;
+
+public class DerivedComplexInputGraph :
+    InputObjectGraphType
+{
+    public DerivedComplexInputGraph()
+    {
+        Field<ComplexInputInnerGraph>("inner");
+
+        Field<ListGraphType<NonNullGraphType<ComplexInputListItemGraph>>>("items");
+
+        Field<StringGraphType>("someProperty");
+    }
+}

--- a/src/Tests/IntegrationTests.DerivedComplexInvalid.verified.txt
+++ b/src/Tests/IntegrationTests.DerivedComplexInvalid.verified.txt
@@ -1,0 +1,19 @@
+{
+  "errors": [
+    {
+      "message": "Inner.Content: 'Content' must not be empty.",
+      "path": [
+        "Inner.Content"
+      ]
+    },
+    {
+      "message": "Items: 'Items' must not be empty.",
+      "path": [
+        "Items"
+      ]
+    }
+  ],
+  "data": {
+    "derivedComplexInputQuery": null
+  }
+}

--- a/src/Tests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests.cs
@@ -146,6 +146,28 @@ public class IntegrationTests
     }
 
     [Fact]
+    public async Task DerivedComplexInvalid()
+    {
+        var queryString = @"
+{
+  derivedComplexInputQuery
+    (
+      input: {
+        inner: {
+          content: """"
+        },
+        items: []
+      }
+    )
+  {
+    data
+  }
+}";
+        var result = await QueryExecutor.ExecuteQuery(queryString, null, typeCache);
+        await Verifier.Verify(result);
+    }
+
+    [Fact]
     public async Task ComplexInvalid2()
     {
         var queryString = @"

--- a/src/Tests/Query.cs
+++ b/src/Tests/Query.cs
@@ -33,6 +33,19 @@ public class Query :
             }
         );
 
+        Field<ResultGraph>(
+            "derivedComplexInputQuery",
+            arguments: new(new QueryArgument<DerivedComplexInputGraph> { Name = "input" }),
+            resolve: context =>
+            {
+                var input = context.GetValidatedArgument<DerivedComplexInput>("input");
+                return new Result
+                {
+                    Data = JsonConvert.SerializeObject(input)
+                };
+            }
+        );
+
         FieldAsync<ResultGraph>(
             "asyncQuery",
             arguments: new(new QueryArgument<InputGraph> { Name = "input" }),


### PR DESCRIPTION
In a scenario, where two input types InputA and InputB have a common base class InputBase with some common properties, it should be possible to have a single validator for the base class. Currently, when there is a validator registered for InputBase, validating an object of InputA does not throw any validation errors although there might be invalid data in InputA.