### PR TITLE
Split ValidatorTypeCache

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,8 +79,8 @@ Validators need to be added to the `ValidatorTypeCache`. This should be done onc
 <!-- snippet: StartConfig -->
 <a id='snippet-startconfig'></a>
 ```cs
-ValidatorTypeCache validatorTypeCache = new();
-validatorTypeCache.AddValidatorsFromAssembly(assemblyContainingValidators);
+ValidatorInstanceCache validatorCache = new();
+validatorCache.AddValidatorsFromAssembly(assemblyContainingValidators);
 Schema schema = new();
 schema.UseFluentValidation();
 DocumentExecuter executer = new();
@@ -109,7 +109,7 @@ ExecutionOptions options = new()
     Query = queryString,
     Inputs = inputs
 };
-options.UseFluentValidation(validatorTypeCache);
+options.UseFluentValidation(validatorCache);
 
 var executionResult = await executer.ExecuteAsync(options);
 ```
@@ -158,7 +158,7 @@ ExecutionOptions options = new()
         myProperty: "the value"
     )
 };
-options.UseFluentValidation(validatorTypeCache);
+options.UseFluentValidation(validatorCache);
 ```
 <sup><a href='/src/Tests/Snippets/QueryExecution.cs#L63-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-executequerywithcontextimplementingdictionary' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -185,7 +185,7 @@ ExecutionOptions options = new()
         }
     }
 };
-options.UseFluentValidation(validatorTypeCache);
+options.UseFluentValidation(validatorCache);
 ```
 <sup><a href='/src/Tests/Snippets/QueryExecution.cs#L82-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-executequerywithcontextinsidedictionary' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -204,7 +204,7 @@ ExecutionOptions options = new()
     Query = queryString,
     Inputs = inputs
 };
-options.UseFluentValidation(validatorTypeCache);
+options.UseFluentValidation(validatorCache);
 ```
 <sup><a href='/src/Tests/Snippets/QueryExecution.cs#L107-L117' title='Snippet source file'>snippet source</a> | <a href='#snippet-nocontext' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,5 +5,6 @@
     <PackageTags>GraphQL, Validation, FluentValidation</PackageTags>
     <Description>Add FluentValidation (https://fluentvalidation.net/) support to GraphQL.net (https://github.com/graphql-dotnet/graphql-dotnet)</Description>
     <SignAssembly>false</SignAssembly>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>6.3.1</Version>
+    <Version>7.0.0</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <PackageTags>GraphQL, Validation, FluentValidation</PackageTags>
     <Description>Add FluentValidation (https://fluentvalidation.net/) support to GraphQL.net (https://github.com/graphql-dotnet/graphql-dotnet)</Description>

--- a/src/GraphQL.FluentValidation/ArgumentTypeCacheBag.cs
+++ b/src/GraphQL.FluentValidation/ArgumentTypeCacheBag.cs
@@ -7,7 +7,7 @@ static class ArgumentTypeCacheBag
 {
     const string key = "GraphQL.FluentValidation.ValidatorTypeCache";
 
-    public static void SetCache(this ExecutionOptions options, ValidatorTypeCache cache)
+    public static void SetCache(this ExecutionOptions options, IValidatorCache cache)
     {
         // ReSharper disable once ConditionIsAlwaysTrueOrFalse
         if (options.UserContext == null)
@@ -22,12 +22,12 @@ static class ArgumentTypeCacheBag
         AddValidatorCache(options.UserContext, cache);
     }
 
-    internal static void AddValidatorCache(this IDictionary<string, object?> dictionary, ValidatorTypeCache cache)
+    internal static void AddValidatorCache(this IDictionary<string, object?> dictionary, IValidatorCache cache)
     {
         dictionary.Add(key, cache);
     }
 
-    public static ValidatorTypeCache GetCache(this IResolveFieldContext context)
+    public static IValidatorCache GetCache(this IResolveFieldContext context)
     {
         if (context.UserContext == null)
         {
@@ -36,10 +36,10 @@ static class ArgumentTypeCacheBag
 
         if (context.UserContext.TryGetValue(key, out var result))
         {
-            return (ValidatorTypeCache)result!;
+            return (IValidatorCache)result!;
         }
 
-        throw new($"Could not extract {nameof(ValidatorTypeCache)} from {nameof(IResolveFieldContext)}.{nameof(IResolveFieldContext.UserContext)}. It is possible {nameof(FluentValidationExtensions)}.{nameof(FluentValidationExtensions.UseFluentValidation)} was not used.");
+        throw new($"Could not extract {nameof(IValidatorCache)} from {nameof(IResolveFieldContext)}.{nameof(IResolveFieldContext.UserContext)}. It is possible {nameof(FluentValidationExtensions)}.{nameof(FluentValidationExtensions.UseFluentValidation)} was not used.");
     }
 
     static Exception NotDictionary()

--- a/src/GraphQL.FluentValidation/ArgumentValidation.cs
+++ b/src/GraphQL.FluentValidation/ArgumentValidation.cs
@@ -16,13 +16,13 @@ namespace GraphQL.FluentValidation
         /// <summary>
         /// Validate an instance
         /// </summary>
-        public static Task ValidateAsync<TArgument>(ValidatorTypeCache cache, Type type, TArgument instance, IDictionary<string, object?> userContext)
+        public static Task ValidateAsync<TArgument>(IValidatorCache cache, Type type, TArgument instance, IDictionary<string, object?> userContext)
             => ValidateAsync(cache, type, instance, userContext, null);
 
         /// <summary>
         /// Validate an instance
         /// </summary>
-        public static async Task ValidateAsync<TArgument>(ValidatorTypeCache cache, Type type, TArgument instance, IDictionary<string, object?> userContext, IServiceProvider? provider, CancellationToken cancellation = default)
+        public static async Task ValidateAsync<TArgument>(IValidatorCache cache, Type type, TArgument instance, IDictionary<string, object?> userContext, IServiceProvider? provider, CancellationToken cancellation = default)
         {
             var currentType = (Type?)type;
             var validationContext = default(ValidationContext<TArgument>);
@@ -49,13 +49,13 @@ namespace GraphQL.FluentValidation
         /// <summary>
         /// Validate an instance
         /// </summary>
-        public static void Validate<TArgument>(ValidatorTypeCache cache, Type type, TArgument instance, IDictionary<string, object?> userContext)
+        public static void Validate<TArgument>(IValidatorCache cache, Type type, TArgument instance, IDictionary<string, object?> userContext)
             => Validate(cache, type, instance, userContext, null);
 
         /// <summary>
         /// Validate an instance
         /// </summary>
-        public static void Validate<TArgument>(ValidatorTypeCache cache, Type type, TArgument instance, IDictionary<string, object?> userContext, IServiceProvider? provider)
+        public static void Validate<TArgument>(IValidatorCache cache, Type type, TArgument instance, IDictionary<string, object?> userContext, IServiceProvider? provider)
         {
             if (instance == null)
             {

--- a/src/GraphQL.FluentValidation/FluentValidationExtensions.cs
+++ b/src/GraphQL.FluentValidation/FluentValidationExtensions.cs
@@ -13,7 +13,7 @@ namespace GraphQL
         /// <summary>
         /// Adds a FieldMiddleware to the GraphQL pipeline that converts a <see cref="ValidationException"/> to <see cref="ExecutionError"/>s./>
         /// </summary>
-        public static ExecutionOptions UseFluentValidation(this ExecutionOptions executionOptions, ValidatorTypeCache validatorTypeCache)
+        public static ExecutionOptions UseFluentValidation(this ExecutionOptions executionOptions, IValidatorCache validatorTypeCache)
         {
             validatorTypeCache.Freeze();
             executionOptions.SetCache(validatorTypeCache);

--- a/src/GraphQL.FluentValidation/FluentValidationExtensions_UserContext.cs
+++ b/src/GraphQL.FluentValidation/FluentValidationExtensions_UserContext.cs
@@ -17,9 +17,9 @@ namespace GraphQL
         }
 
         /// <summary>
-        /// Injects a <see cref="ValidatorTypeCache" /> instance into a user context for testing purposes.
+        /// Injects a <see cref="IValidatorCache" /> instance into a user context for testing purposes.
         /// </summary>
-        public static void AddCacheToContext<T>(T userContext, ValidatorTypeCache cache)
+        public static void AddCacheToContext<T>(T userContext, IValidatorCache cache)
             where T : Dictionary<string, object?>
         {
             userContext.AddValidatorCache(cache);

--- a/src/GraphQL.FluentValidation/IValidatorCache.cs
+++ b/src/GraphQL.FluentValidation/IValidatorCache.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using FluentValidation;
+
+namespace GraphQL.FluentValidation
+{
+    public interface IValidatorCache
+    {
+        bool IsFrozen { get; }
+        void Freeze();
+        bool TryGetValidators(Type argumentType, IServiceProvider? provider, [NotNullWhen(true)] out IEnumerable<IValidator>? validators);
+        void AddResult(AssemblyScanner.AssemblyScanResult result);
+    }
+}

--- a/src/GraphQL.FluentValidation/ValidatorCacheExtensions.cs
+++ b/src/GraphQL.FluentValidation/ValidatorCacheExtensions.cs
@@ -7,14 +7,6 @@ namespace GraphQL.FluentValidation
 {
     public static class ValidatorCacheExtensions
     {
-        static void ThrowIfFrozen(this IValidatorCache cache)
-        {
-            if (cache.IsFrozen)
-            {
-                throw new InvalidOperationException($"{nameof(IValidatorCache)} cannot be changed once it has been used. Use a new instance instead.");
-            }
-        }
-
         /// <summary>
         /// Add all <see cref="IValidator"/>s from the assembly that contains <typeparamref name="T"/>.
         /// </summary>
@@ -36,7 +28,10 @@ namespace GraphQL.FluentValidation
         /// </summary>
         public static IValidatorCache AddValidatorsFromAssembly(this IValidatorCache cache, Assembly assembly, bool throwIfNoneFound = true)
         {
-            cache.ThrowIfFrozen();
+            if (cache.IsFrozen)
+            {
+                throw new InvalidOperationException($"{nameof(IValidatorCache)} cannot be changed once it has been used. Use a new instance instead.");
+            }
 
             var results = AssemblyScanner.FindValidatorsInAssembly(assembly).ToList();
             if (!results.Any())

--- a/src/GraphQL.FluentValidation/ValidatorCacheExtensions.cs
+++ b/src/GraphQL.FluentValidation/ValidatorCacheExtensions.cs
@@ -7,18 +7,18 @@ namespace GraphQL.FluentValidation
 {
     public static class ValidatorCacheExtensions
     {
-        static void ThrowIfFrozen(this ValidatorTypeCache cache)
+        static void ThrowIfFrozen(this IValidatorCache cache)
         {
             if (cache.IsFrozen)
             {
-                throw new InvalidOperationException($"{nameof(ValidatorTypeCache)} cannot be changed once it has been used. Use a new instance instead.");
+                throw new InvalidOperationException($"{nameof(IValidatorCache)} cannot be changed once it has been used. Use a new instance instead.");
             }
         }
 
         /// <summary>
         /// Add all <see cref="IValidator"/>s from the assembly that contains <typeparamref name="T"/>.
         /// </summary>
-        public static ValidatorTypeCache AddValidatorsFromAssemblyContaining<T>(this ValidatorTypeCache cache, bool throwIfNoneFound = true)
+        public static IValidatorCache AddValidatorsFromAssemblyContaining<T>(this IValidatorCache cache, bool throwIfNoneFound = true)
         {
             return AddValidatorsFromAssemblyContaining(cache, typeof(T), throwIfNoneFound);
         }
@@ -26,7 +26,7 @@ namespace GraphQL.FluentValidation
         /// <summary>
         /// Add all <see cref="IValidator"/>s from the assembly that contains <paramref name="type"/>.
         /// </summary>
-        public static ValidatorTypeCache AddValidatorsFromAssemblyContaining(this ValidatorTypeCache cache, Type type, bool throwIfNoneFound = true)
+        public static IValidatorCache AddValidatorsFromAssemblyContaining(this IValidatorCache cache, Type type, bool throwIfNoneFound = true)
         {
             return AddValidatorsFromAssembly(cache, type.Assembly, throwIfNoneFound);
         }
@@ -34,7 +34,7 @@ namespace GraphQL.FluentValidation
         /// <summary>
         /// Add all <see cref="IValidator"/>s in <paramref name="assembly"/>.
         /// </summary>
-        public static ValidatorTypeCache AddValidatorsFromAssembly(this ValidatorTypeCache cache, Assembly assembly, bool throwIfNoneFound = true)
+        public static IValidatorCache AddValidatorsFromAssembly(this IValidatorCache cache, Assembly assembly, bool throwIfNoneFound = true)
         {
             cache.ThrowIfFrozen();
 

--- a/src/GraphQL.FluentValidation/ValidatorCacheExtensions.cs
+++ b/src/GraphQL.FluentValidation/ValidatorCacheExtensions.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using FluentValidation;
+
+namespace GraphQL.FluentValidation
+{
+    public static class ValidatorCacheExtensions
+    {
+        /// <summary>
+        /// Add all <see cref="IValidator"/>s from the assembly that contains <typeparamref name="T"/>.
+        /// </summary>
+        public static ValidatorTypeCache AddValidatorsFromAssemblyContaining<T>(this ValidatorTypeCache cache, bool throwIfNoneFound = true)
+        {
+            return AddValidatorsFromAssemblyContaining(cache, typeof(T), throwIfNoneFound);
+        }
+
+        /// <summary>
+        /// Add all <see cref="IValidator"/>s from the assembly that contains <paramref name="type"/>.
+        /// </summary>
+        public static ValidatorTypeCache AddValidatorsFromAssemblyContaining(this ValidatorTypeCache cache, Type type, bool throwIfNoneFound = true)
+        {
+            return AddValidatorsFromAssembly(cache, type.Assembly, throwIfNoneFound);
+        }
+
+        /// <summary>
+        /// Add all <see cref="IValidator"/>s in <paramref name="assembly"/>.
+        /// </summary>
+        public static ValidatorTypeCache AddValidatorsFromAssembly(this ValidatorTypeCache cache, Assembly assembly, bool throwIfNoneFound = true)
+        {
+            cache.ThrowIfFrozen();
+
+            var results = AssemblyScanner.FindValidatorsInAssembly(assembly).ToList();
+            if (!results.Any())
+            {
+                if (throwIfNoneFound)
+                {
+                    throw new($"No validators were found in {assembly.GetName().Name}.");
+                }
+
+                return cache;
+            }
+
+            foreach (var result in results)
+            {
+                var validatorType = result.ValidatorType;
+                if (validatorType.IsAbstract)
+                {
+                    continue;
+                }
+
+                cache.AddResult(result);
+            }
+
+            return cache;
+        }
+    }
+}

--- a/src/GraphQL.FluentValidation/ValidatorCacheExtensions.cs
+++ b/src/GraphQL.FluentValidation/ValidatorCacheExtensions.cs
@@ -7,6 +7,14 @@ namespace GraphQL.FluentValidation
 {
     public static class ValidatorCacheExtensions
     {
+        static void ThrowIfFrozen(this ValidatorTypeCache cache)
+        {
+            if (cache.IsFrozen)
+            {
+                throw new InvalidOperationException($"{nameof(ValidatorTypeCache)} cannot be changed once it has been used. Use a new instance instead.");
+            }
+        }
+
         /// <summary>
         /// Add all <see cref="IValidator"/>s from the assembly that contains <typeparamref name="T"/>.
         /// </summary>

--- a/src/GraphQL.FluentValidation/ValidatorServiceCache.cs
+++ b/src/GraphQL.FluentValidation/ValidatorServiceCache.cs
@@ -12,7 +12,7 @@ namespace GraphQL.FluentValidation
     /// Should only be configured once at startup time.
     /// Uses <see cref="IServiceProvider"/> for resolving <see cref="IValidator"/>s.
     /// </summary>
-    public class ValidatorTypeCache : IValidatorCache
+    public class ValidatorServiceCache : IValidatorCache
     {
         Dictionary<Type, List<Type>>? cache = new();
 

--- a/src/GraphQL.FluentValidation/ValidatorTypeCache.cs
+++ b/src/GraphQL.FluentValidation/ValidatorTypeCache.cs
@@ -8,11 +8,19 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.FluentValidation
 {
+    public interface IValidatorCache
+    {
+        bool IsFrozen { get; }
+        void Freeze();
+        bool TryGetValidators(Type argumentType, IServiceProvider? provider, [NotNullWhen(true)] out IEnumerable<IValidator>? validators);
+        void AddResult(AssemblyScanner.AssemblyScanResult result);
+    }
+
     /// <summary>
     /// Cache for all <see cref="IValidator"/>.
     /// Should only be configured once at startup time.
     /// </summary>
-    public class ValidatorTypeCache
+    public class ValidatorTypeCache : IValidatorCache
     {
         Dictionary<Type, List<IValidator>>? typeCache;
         Dictionary<Type, List<Type>>? typeCacheDI;
@@ -52,7 +60,7 @@ namespace GraphQL.FluentValidation
             IsFrozen = true;
         }
 
-        internal bool TryGetValidators(Type argumentType, IServiceProvider? provider, [NotNullWhen(true)] out IEnumerable<IValidator>? validators)
+        public bool TryGetValidators(Type argumentType, IServiceProvider? provider, [NotNullWhen(true)] out IEnumerable<IValidator>? validators)
         {
             if (UseDI)
             {

--- a/src/GraphQL.FluentValidation/ValidatorTypeCache.cs
+++ b/src/GraphQL.FluentValidation/ValidatorTypeCache.cs
@@ -16,7 +16,6 @@ namespace GraphQL.FluentValidation
     {
         Dictionary<Type, List<IValidator>>? typeCache;
         Dictionary<Type, List<Type>>? typeCacheDI;
-        bool isFrozen;
 
         /// <summary>
         /// Create cache with default DI behavior i.e. cache creates all validators itself.
@@ -46,17 +45,11 @@ namespace GraphQL.FluentValidation
 
         private bool UseDI => typeCacheDI != null;
 
+        public bool IsFrozen { get; private set; }
+
         public void Freeze()
         {
-            isFrozen = true;
-        }
-
-        public void ThrowIfFrozen()
-        {
-            if (isFrozen)
-            {
-                throw new InvalidOperationException($"{nameof(ValidatorTypeCache)} cannot be changed once it has been used. Use a new instance instead.");
-            }
+            IsFrozen = true;
         }
 
         internal bool TryGetValidators(Type argumentType, IServiceProvider? provider, [NotNullWhen(true)] out IEnumerable<IValidator>? validators)

--- a/src/GraphQL.FluentValidation/ValidatorTypeCache.cs
+++ b/src/GraphQL.FluentValidation/ValidatorTypeCache.cs
@@ -8,14 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.FluentValidation
 {
-    public interface IValidatorCache
-    {
-        bool IsFrozen { get; }
-        void Freeze();
-        bool TryGetValidators(Type argumentType, IServiceProvider? provider, [NotNullWhen(true)] out IEnumerable<IValidator>? validators);
-        void AddResult(AssemblyScanner.AssemblyScanResult result);
-    }
-
     /// <summary>
     /// Cache for all <see cref="IValidator"/>.
     /// Should only be configured once at startup time.

--- a/src/GraphQL.FluentValidation/ValidatorTypeCache.cs
+++ b/src/GraphQL.FluentValidation/ValidatorTypeCache.cs
@@ -46,7 +46,7 @@ namespace GraphQL.FluentValidation
 
         private bool UseDI => typeCacheDI != null;
 
-        internal void Freeze()
+        public void Freeze()
         {
             isFrozen = true;
         }

--- a/src/GraphQL.FluentValidation/ValidatorTypeCache.cs
+++ b/src/GraphQL.FluentValidation/ValidatorTypeCache.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Reflection;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -114,57 +113,6 @@ namespace GraphQL.FluentValidation
 
                 list.Add((IValidator)Activator.CreateInstance(result.ValidatorType, true)!);
             }
-        }
-    }
-
-    public static class ValidatorCacheExtensions
-    {
-        /// <summary>
-        /// Add all <see cref="IValidator"/>s from the assembly that contains <typeparamref name="T"/>.
-        /// </summary>
-        public static ValidatorTypeCache AddValidatorsFromAssemblyContaining<T>(this ValidatorTypeCache cache, bool throwIfNoneFound = true)
-        {
-            return AddValidatorsFromAssemblyContaining(cache, typeof(T), throwIfNoneFound);
-        }
-
-        /// <summary>
-        /// Add all <see cref="IValidator"/>s from the assembly that contains <paramref name="type"/>.
-        /// </summary>
-        public static ValidatorTypeCache AddValidatorsFromAssemblyContaining(this ValidatorTypeCache cache, Type type, bool throwIfNoneFound = true)
-        {
-            return AddValidatorsFromAssembly(cache, type.Assembly, throwIfNoneFound);
-        }
-
-        /// <summary>
-        /// Add all <see cref="IValidator"/>s in <paramref name="assembly"/>.
-        /// </summary>
-        public static ValidatorTypeCache AddValidatorsFromAssembly(this ValidatorTypeCache cache, Assembly assembly, bool throwIfNoneFound = true)
-        {
-            cache.ThrowIfFrozen();
-
-            var results = AssemblyScanner.FindValidatorsInAssembly(assembly).ToList();
-            if (!results.Any())
-            {
-                if (throwIfNoneFound)
-                {
-                    throw new($"No validators were found in {assembly.GetName().Name}.");
-                }
-
-                return cache;
-            }
-
-            foreach (var result in results)
-            {
-                var validatorType = result.ValidatorType;
-                if (validatorType.IsAbstract)
-                {
-                    continue;
-                }
-
-                cache.AddResult(result);
-            }
-
-            return cache;
         }
     }
 }

--- a/src/SampleWeb/ValidatorCacheBuilder.cs
+++ b/src/SampleWeb/ValidatorCacheBuilder.cs
@@ -2,16 +2,16 @@
 
 public static class ValidatorCacheBuilder
 {
-    public static ValidatorTypeCache Instance;
+    public static ValidatorInstanceCache Instance;
 
     public static ValidatorTypeCache InstanceDI;
 
     static ValidatorCacheBuilder()
     {
-        Instance = new(useDependencyInjection: false);
+        Instance = new();
         Instance.AddValidatorsFromAssembly(typeof(Startup).Assembly);
 
-        InstanceDI = new(useDependencyInjection: true);
+        InstanceDI = new();
         InstanceDI.AddValidatorsFromAssembly(typeof(Startup).Assembly);
     }
 }

--- a/src/SampleWeb/ValidatorCacheBuilder.cs
+++ b/src/SampleWeb/ValidatorCacheBuilder.cs
@@ -4,7 +4,7 @@ public static class ValidatorCacheBuilder
 {
     public static ValidatorInstanceCache Instance;
 
-    public static ValidatorTypeCache InstanceDI;
+    public static ValidatorServiceCache InstanceDI;
 
     static ValidatorCacheBuilder()
     {

--- a/src/Tests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 [UsesVerify]
 public class IntegrationTests
 {
-    static IValidatorCache typeCache = new ValidatorTypeCache().AddValidatorsFromAssemblyContaining<IntegrationTests>();
+    static IValidatorCache typeCache = new ValidatorInstanceCache().AddValidatorsFromAssemblyContaining<IntegrationTests>();
 
     [Fact]
     public async Task AsyncValid()

--- a/src/Tests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 [UsesVerify]
 public class IntegrationTests
 {
-    static ValidatorTypeCache typeCache = new ValidatorTypeCache().AddValidatorsFromAssemblyContaining<IntegrationTests>();
+    static IValidatorCache typeCache = new ValidatorTypeCache().AddValidatorsFromAssemblyContaining<IntegrationTests>();
 
     [Fact]
     public async Task AsyncValid()

--- a/src/Tests/QueryExecutor.cs
+++ b/src/Tests/QueryExecutor.cs
@@ -6,7 +6,7 @@ using GraphQL.NewtonsoftJson;
 
 static class QueryExecutor
 {
-    public static async Task<string> ExecuteQuery(string queryString, Inputs? inputs, ValidatorTypeCache cache)
+    public static async Task<string> ExecuteQuery(string queryString, Inputs? inputs, IValidatorCache cache)
     {
         Thread.CurrentThread.CurrentUICulture = new("en-US");
 

--- a/src/Tests/Snippets/QueryExecution.cs
+++ b/src/Tests/Snippets/QueryExecution.cs
@@ -10,15 +10,15 @@ class QueryExecution
     string queryString = null!;
     Inputs inputs = null!;
     Schema schema = null!;
-    ValidatorTypeCache validatorTypeCache = null!;
+    ValidatorInstanceCache validatorCache = null!;
     DocumentExecuter executer = null!;
 
     void ExecuteQuery(Assembly assemblyContainingValidators)
     {
         #region StartConfig
 
-        ValidatorTypeCache validatorTypeCache = new();
-        validatorTypeCache.AddValidatorsFromAssembly(assemblyContainingValidators);
+        ValidatorInstanceCache validatorCache = new();
+        validatorCache.AddValidatorsFromAssembly(assemblyContainingValidators);
         Schema schema = new();
         schema.UseFluentValidation();
         DocumentExecuter executer = new();
@@ -36,7 +36,7 @@ class QueryExecution
             Query = queryString,
             Inputs = inputs
         };
-        options.UseFluentValidation(validatorTypeCache);
+        options.UseFluentValidation(validatorCache);
 
         var executionResult = await executer.ExecuteAsync(options);
 
@@ -72,7 +72,7 @@ class QueryExecution
                 myProperty: "the value"
             )
         };
-        options.UseFluentValidation(validatorTypeCache);
+        options.UseFluentValidation(validatorCache);
 
         #endregion
     }
@@ -97,7 +97,7 @@ class QueryExecution
                 }
             }
         };
-        options.UseFluentValidation(validatorTypeCache);
+        options.UseFluentValidation(validatorCache);
 
         #endregion
     }
@@ -112,7 +112,7 @@ class QueryExecution
             Query = queryString,
             Inputs = inputs
         };
-        options.UseFluentValidation(validatorTypeCache);
+        options.UseFluentValidation(validatorCache);
 
         #endregion
     }


### PR DESCRIPTION
`ValidatorTypeCache` is now split into two implementation:

 * If using `ValidatorTypeCache(useDependencyInjection: true)` then move to `ValidatorServiceCache()`
 * If using `ValidatorTypeCache(useDependencyInjection: false)` or `ValidatorTypeCache()`, then move to `ValidatorInstanceCache`