### PR TITLE
UseFluentValidation already works on ISchema.

### DIFF
--- a/src/GraphQL.FluentValidation/FluentValidationExtensions.cs
+++ b/src/GraphQL.FluentValidation/FluentValidationExtensions.cs
@@ -23,7 +23,7 @@ public static partial class FluentValidationExtensions
     /// <summary>
     /// Adds a FieldMiddleware to the GraphQL pipeline that converts a <see cref="ValidationException"/> to <see cref="ExecutionError"/>s./>
     /// </summary>
-    public static void UseFluentValidation(this Schema schema)
+    public static void UseFluentValidation(this ISchema schema)
     {
         ValidationMiddleware validationMiddleware = new();
         schema.FieldMiddleware.Use(validationMiddleware);


### PR DESCRIPTION
Let the `UseFluentValidation` method already work on ISchema.

The rationale behind this is that, for GraphQL in ASP.NET Core, there's a nice `ConfigureSchema` extension where `UseFluentValidation` would fit in perfectly, however, it gives you an `ISchema` instead of a `Schema`.

In a subsequent PR, I'd create a PR with a new project for ASP.NET Core with a convenience extension to add fluent validation in one spot....unless there's already something like it ?