### PR TITLE
Improved DI and GraphQL builder support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,35 @@ public class MyInputValidator :
 <!-- endSnippet -->
 
 
-### Setup Validators
+### Setup Validation with the GraphQL Builder
+
+If you are using the GraphQL builder to configure your app and you want to use dependency injection, you can use the builder to configure FluentValidation.  You must first call one of the `AddValidatorsFrom*` methods from
+[FluentValidation.DependencyInjectionExtensions](https://www.nuget.org/packages/FluentValidation.DependencyInjectionExtensions/) to register your validators with the service collection.  Then call the `UseFluentValidation()` extension method when configuring GraphQL.
+
+
+```cs
+var builder = WebApplication.CreateBuilder(args);
+
+var validatorAssembly = /* Get assembly containing validators */;
+builder.Services.AddValidatorsFromAssembly(validatorAssembly);
+
+builder.Services.AddGraphQL(
+    b => b.AddSchema<YourSchemaType>()
+        .UseFluentValidation()
+        // Other GraphQL configuration options...
+);
+
+// Other DI and Asp.Net setup...
+
+```
+
+Note: If you are using a `Startup` class instead of top-level statements, the above configuration will go in your `Startup.ConfigureServices()` method.
+
+### Setup Validation Manually
+
+If you aren't using the GraphQL builder extensions to configure your project, you can manually add the pieces needed to support FluentValidation.
+
+#### Build the Validator Cache
 
 Validators need to be added to the `ValidatorTypeCache`. This should be done once at application startup.
 
@@ -79,13 +107,8 @@ var executer = new DocumentExecuter();
 
 Generally `ValidatorTypeCache` is scoped per app and can be collocated with `Schema`, `DocumentExecuter` initialization.
 
-Dependency Injection can be used for validators. Create a `ValidatorTypeCache` with the
-`useDependencyInjection: true` parameter and call one of the `AddValidatorsFrom*` methods from
-[FluentValidation.DependencyInjectionExtensions](https://www.nuget.org/packages/FluentValidation.DependencyInjectionExtensions/)
-package in the `Startup`. By default, validators are added to the DI container with a transient lifetime.
 
-
-### Add to ExecutionOptions
+#### Add to ExecutionOptions
 
 Validation needs to be added to any instance of `ExecutionOptions`.
 

--- a/src/GraphQL.FluentValidation/FluentValidationExtensions.cs
+++ b/src/GraphQL.FluentValidation/FluentValidationExtensions.cs
@@ -73,59 +73,19 @@ public static partial class FluentValidationExtensions
     /// <param name="builder">
     /// The GraphQL builder.
     /// </param>
-    /// <param name="assemblies">
-    /// The list of assemblies containing validators.  All validators in these assemblies will be loaded.  For full
-    /// control over which validators are loaded, you may build your own <see cref="IValidatorCache"/> and use the
-    /// <see cref="FluentValidationExtensions.UseFluentValidation(IGraphQLBuilder, IValidatorCache)"/> overload.
-    /// </param>
     /// <returns>
     /// The <paramref name="builder"/> instance;
     /// </returns>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="builder"/> is null.
-    /// -or-
-    /// <paramref name="assemblies"/> is null.
     /// </exception>
-    public static IGraphQLBuilder UseFluentValidation(this IGraphQLBuilder builder, params Assembly[] assemblies) =>
-        builder.UseFluentValidation((IEnumerable<Assembly>)assemblies);
-
-    /// <summary>
-    /// Configures GraphQL to use FluentValidation, with validators resolved using dependency injection.
-    /// </summary>
-    /// <param name="builder">
-    /// The GraphQL builder.
-    /// </param>
-    /// <param name="assemblies">
-    /// The list of assemblies containing validators.  All validators in these assemblies will be loaded.  For full
-    /// control over which validators are loaded, you may build your own <see cref="IValidatorCache"/> and use the
-    /// <see cref="FluentValidationExtensions.UseFluentValidation(IGraphQLBuilder, IValidatorCache)"/> overload.
-    /// </param>
-    /// <returns>
-    /// The <paramref name="builder"/> instance;
-    /// </returns>
-    /// <exception cref="ArgumentNullException">
-    /// <paramref name="builder"/> is null.
-    /// -or-
-    /// <paramref name="assemblies"/> is null.
-    /// </exception>
-    public static IGraphQLBuilder UseFluentValidation(this IGraphQLBuilder builder, IEnumerable<Assembly> assemblies)
+    public static IGraphQLBuilder UseFluentValidation(this IGraphQLBuilder builder)
     {
         if (builder is null)
         {
             throw new ArgumentNullException(nameof(builder));
         }
 
-        if (assemblies is null)
-        {
-            throw new ArgumentNullException(nameof(assemblies));
-        }
-
-        var validatorCache = new ValidatorServiceCache();
-        foreach (var assembly in assemblies)
-        {
-            validatorCache.AddValidatorsFromAssembly(assembly);
-        }
-
-        return builder.UseFluentValidation(validatorCache);
+        return builder.UseFluentValidation(new ValidatorServiceProviderCache());
     }
 }

--- a/src/GraphQL.FluentValidation/FluentValidationExtensions.cs
+++ b/src/GraphQL.FluentValidation/FluentValidationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using GraphQL.DI;
 using GraphQL.FluentValidation;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
@@ -27,5 +28,104 @@ public static partial class FluentValidationExtensions
     {
         ValidationMiddleware validationMiddleware = new();
         schema.FieldMiddleware.Use(validationMiddleware);
+    }
+
+    /// <summary>
+    /// Configures GraphQL to use FluentValidation, using a custom <see cref="IValidatorCache"/>.
+    /// </summary>
+    /// <param name="builder">
+    /// The GraphQL builder.
+    /// </param>
+    /// <param name="validatorCache">
+    /// The cache used to resolve validator types.
+    /// </param>
+    /// <returns>
+    /// The <paramref name="builder"/> instance;
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder"/> is null.
+    /// -or-
+    /// <paramref name="validatorCache"/> is null.
+    /// </exception>
+    public static IGraphQLBuilder UseFluentValidation(this IGraphQLBuilder builder, IValidatorCache validatorCache)
+    {
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        if (validatorCache is null)
+        {
+            throw new ArgumentNullException(nameof(validatorCache));
+        }
+
+        builder.UseMiddleware<ValidationMiddleware>();
+
+        validatorCache.Freeze();
+        builder.ConfigureExecutionOptions(eo => eo.SetCache(validatorCache));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures GraphQL to use FluentValidation, with validators resolved using dependency injection.
+    /// </summary>
+    /// <param name="builder">
+    /// The GraphQL builder.
+    /// </param>
+    /// <param name="assemblies">
+    /// The list of assemblies containing validators.  All validators in these assemblies will be loaded.  For full
+    /// control over which validators are loaded, you may build your own <see cref="IValidatorCache"/> and use the
+    /// <see cref="FluentValidationExtensions.UseFluentValidation(IGraphQLBuilder, IValidatorCache)"/> overload.
+    /// </param>
+    /// <returns>
+    /// The <paramref name="builder"/> instance;
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder"/> is null.
+    /// -or-
+    /// <paramref name="assemblies"/> is null.
+    /// </exception>
+    public static IGraphQLBuilder UseFluentValidation(this IGraphQLBuilder builder, params Assembly[] assemblies) =>
+        builder.UseFluentValidation((IEnumerable<Assembly>)assemblies);
+
+    /// <summary>
+    /// Configures GraphQL to use FluentValidation, with validators resolved using dependency injection.
+    /// </summary>
+    /// <param name="builder">
+    /// The GraphQL builder.
+    /// </param>
+    /// <param name="assemblies">
+    /// The list of assemblies containing validators.  All validators in these assemblies will be loaded.  For full
+    /// control over which validators are loaded, you may build your own <see cref="IValidatorCache"/> and use the
+    /// <see cref="FluentValidationExtensions.UseFluentValidation(IGraphQLBuilder, IValidatorCache)"/> overload.
+    /// </param>
+    /// <returns>
+    /// The <paramref name="builder"/> instance;
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder"/> is null.
+    /// -or-
+    /// <paramref name="assemblies"/> is null.
+    /// </exception>
+    public static IGraphQLBuilder UseFluentValidation(this IGraphQLBuilder builder, IEnumerable<Assembly> assemblies)
+    {
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        if (assemblies is null)
+        {
+            throw new ArgumentNullException(nameof(assemblies));
+        }
+
+        var validatorCache = new ValidatorServiceCache();
+        foreach (var assembly in assemblies)
+        {
+            validatorCache.AddValidatorsFromAssembly(assembly);
+        }
+
+        return builder.UseFluentValidation(validatorCache);
     }
 }

--- a/src/GraphQL.FluentValidation/ValidatorServiceProviderCache.cs
+++ b/src/GraphQL.FluentValidation/ValidatorServiceProviderCache.cs
@@ -1,0 +1,40 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.FluentValidation;
+
+/// <summary>
+/// Uses the <see cref="IServiceProvider"/> to determine what validators are available and resolve validator instances.
+/// </summary>
+sealed class ValidatorServiceProviderCache : IValidatorCache
+{
+    /// <inheritdoc />
+    public bool IsFrozen => true;
+
+    /// <inheritdoc />
+    public void Freeze()
+    {
+        // Intentionally empty.
+    }
+
+    /// <inheritdoc />
+    public bool TryGetValidators(Type argumentType, IServiceProvider? provider, [NotNullWhen(true)] out IEnumerable<IValidator>? validators)
+    {
+        var validatorType = typeof(IValidator<>).MakeGenericType(argumentType);
+        try
+        {
+            validators = provider!.GetServices(validatorType).Cast<IValidator>();
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            validators = null;
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public void AddResult(AssemblyScanner.AssemblyScanResult result) =>
+        throw new InvalidOperationException("Method not supported.  The service provider cache uses IServiceProvider to determine what validators are available.");
+}


### PR DESCRIPTION
I discovered the library today, but it took a while to figure out how to set it up to work with the `IGraphQLBuilder`  that [GraphQL.Net now provides for DI setup](https://graphql-dotnet.github.io/docs/getting-started/dependency-injection#dependency-injection-registration-helpers).  Once I got it working, I realized that the configuration could be wrapped in a single method working with the builder.  Also, when working with DI we don't actually need a validator cache (the user registers their validators with DI, we query DI to find out what validators are available), allowing setup to be simplified even more.

Changes in this PR:

* Add default builder configuration method that uses DI to resolve validators.
* Add configuration overload method if the user does not want to use DI and wishes to provider an `IValidatorCache`.
* Add `ValidatorServiceProviderCache` which doesn't actually hold a cache, it just does lookups in the service provider to see what validators are available.  IMO this should deprecate `ValidatorServiceCache`, but I wasn't able to mark it as obsolete due to obsolete warnings being treated as errors.
* Update readme to describe the new simplified configuration.