### PR TITLE
Expose request IServiceProvider to validators

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -231,6 +231,32 @@ public class Query :
 <!-- endSnippet -->
 
 
+### Accessing services in validators
+
+When validation is triggered via `GetValidatedArgument`, the `IResolveFieldContext.RequestServices` for the current request is exposed to validators through the validation context. A rule can therefore resolve services — for example the current time, configuration, or a repository — from the request scope, which keeps the rule unit-testable:
+
+<!-- snippet: ServiceProviderInValidator -->
+<a id='snippet-ServiceProviderInValidator'></a>
+```cs
+public class BookingInputValidator :
+    AbstractValidator<BookingInput>
+{
+    public BookingInputValidator() =>
+        RuleFor(_ => _.Start)
+            .Must((_, start, context) =>
+            {
+                var clock = context.GetRequiredService<TimeProvider>();
+                return start >= clock.GetUtcNow();
+            })
+            .WithMessage("Start cannot be in the past");
+}
+```
+<sup><a href='/src/SampleWeb/Graphs/ServiceInValidator.cs#L9-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-ServiceProviderInValidator' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Use `context.GetRequiredService<T>()` to resolve a required service. To access the underlying `IServiceProvider` directly, use `context.GetServiceProvider()`, or `context.TryGetServiceProvider(out var provider)` when validation may run without one.
+
+
 ### Difference from IValidationRule
 
 The validation implemented in this project has nothing to do with the validation of the incoming GraphQL

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <LangVersion>preview</LangVersion>
     <PackageTags>GraphQL, Validation, FluentValidation</PackageTags>

--- a/src/GraphQL.FluentValidation/ArgumentValidation.cs
+++ b/src/GraphQL.FluentValidation/ArgumentValidation.cs
@@ -25,7 +25,7 @@ public static class ArgumentValidation
         {
             if (cache.TryGetValidators(currentType, provider, out var buildAll))
             {
-                validationContext ??= BuildValidationContext(instance, userContext);
+                validationContext ??= BuildValidationContext(instance, userContext, provider);
 
                 var tasks = buildAll.Select(_ => _.ValidateAsync(validationContext, cancel));
                 var validationResults = await Task.WhenAll(tasks);
@@ -68,7 +68,7 @@ public static class ArgumentValidation
         {
             if (cache.TryGetValidators(currentType, provider, out var buildAll))
             {
-                validationContext ??= BuildValidationContext(instance, userContext);
+                validationContext ??= BuildValidationContext(instance, userContext, provider);
                 var results = buildAll
                     .SelectMany(validator => validator.Validate(validationContext).Errors);
 
@@ -88,10 +88,15 @@ public static class ArgumentValidation
         }
     }
 
-    static ValidationContext<TArgument> BuildValidationContext<TArgument>(TArgument instance, IDictionary<string, object?> userContext)
+    static ValidationContext<TArgument> BuildValidationContext<TArgument>(TArgument instance, IDictionary<string, object?> userContext, IServiceProvider? provider)
     {
         ValidationContext<TArgument> validationContext = new(instance);
         validationContext.RootContextData.Add("UserContext", userContext);
+        if (provider != null)
+        {
+            validationContext.RootContextData.Add("ServiceProvider", provider);
+        }
+
         return validationContext;
     }
 }

--- a/src/GraphQL.FluentValidation/FluentValidationExtensions_ServiceProvider.cs
+++ b/src/GraphQL.FluentValidation/FluentValidationExtensions_ServiceProvider.cs
@@ -1,0 +1,46 @@
+namespace GraphQL;
+
+public static partial class FluentValidationExtensions
+{
+    /// <summary>
+    /// When performing validation via GetValidatedArgument, the <see cref="IResolveFieldContext.RequestServices"/>
+    /// instance is added to <see cref="IValidationContext.RootContextData"/> with a key of "ServiceProvider".
+    /// During validation that instance can be retrieved from <see cref="IValidationContext"/> using this method.
+    /// Returns false when validation is performed without an <see cref="IServiceProvider"/>.
+    /// </summary>
+    public static bool TryGetServiceProvider(this IValidationContext validationContext, [NotNullWhen(true)] out IServiceProvider? serviceProvider)
+    {
+        if (validationContext.RootContextData.TryGetValue("ServiceProvider", out var value) &&
+            value is IServiceProvider provider)
+        {
+            serviceProvider = provider;
+            return true;
+        }
+
+        serviceProvider = null;
+        return false;
+    }
+
+    /// <summary>
+    /// The <see cref="IServiceProvider"/> captured during validation (see <see cref="TryGetServiceProvider"/>).
+    /// Throws if validation is performed without an <see cref="IServiceProvider"/>.
+    /// </summary>
+    public static IServiceProvider GetServiceProvider(this IValidationContext validationContext)
+    {
+        if (validationContext.TryGetServiceProvider(out var provider))
+        {
+            return provider;
+        }
+
+        throw new("No IServiceProvider is available in the validation context. Validate via IResolveFieldContext.GetValidatedArgument (which passes RequestServices), or pass an IServiceProvider to ArgumentValidation.Validate/ValidateAsync.");
+    }
+
+    /// <summary>
+    /// Resolves a service of type <typeparamref name="T"/> from the <see cref="IServiceProvider"/> captured during
+    /// validation. Throws if no service provider is available (see <see cref="GetServiceProvider"/>) or the service
+    /// is not registered.
+    /// </summary>
+    public static T GetRequiredService<T>(this IValidationContext validationContext)
+        where T : notnull =>
+        validationContext.GetServiceProvider().GetRequiredService<T>();
+}

--- a/src/SampleWeb/Graphs/ServiceInValidator.cs
+++ b/src/SampleWeb/Graphs/ServiceInValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+using GraphQL;
+
+public class BookingInput
+{
+    public DateTimeOffset Start { get; set; }
+}
+
+#region ServiceProviderInValidator
+public class BookingInputValidator :
+    AbstractValidator<BookingInput>
+{
+    public BookingInputValidator() =>
+        RuleFor(_ => _.Start)
+            .Must((_, start, context) =>
+            {
+                var clock = context.GetRequiredService<TimeProvider>();
+                return start >= clock.GetUtcNow();
+            })
+            .WithMessage("Start cannot be in the past");
+}
+#endregion

--- a/src/Tests/Arguments/AsyncComplexInputValidator.cs
+++ b/src/Tests/Arguments/AsyncComplexInputValidator.cs
@@ -6,6 +6,7 @@ public class AsyncComplexInputValidator :
     public AsyncComplexInputValidator() =>
         RuleFor(_ => _.Inner!)
             .NotEmpty()
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
             .MustAsync((o, _) => Task.FromResult(o != null && !string.IsNullOrWhiteSpace(o.Content)))
             .WithMessage("Inner async test failed msg.")
             .SetValidator(new ComplexInputInnerValidator());

--- a/src/Tests/ServiceProviderTests.cs
+++ b/src/Tests/ServiceProviderTests.cs
@@ -1,0 +1,71 @@
+using FluentValidation;
+using GraphQL;
+using GraphQL.FluentValidation;
+
+public class ServiceProviderTests
+{
+    [Fact]
+    public void ResolvesServiceFromValidationContext()
+    {
+        var provider = new StubProvider(new("resolved-from-provider"));
+        var cache = BuildCache(new ServiceReadingValidator());
+
+        var exception = Assert.Throws<ValidationException>(
+            () => ArgumentValidation.Validate(cache, typeof(TheInput), new TheInput(), new Dictionary<string, object?>(), provider));
+
+        Assert.Contains("resolved-from-provider", exception.Message);
+    }
+
+    [Fact]
+    public void TryGetServiceProviderIsFalseWhenNotSupplied()
+    {
+        var cache = BuildCache(new ProviderProbeValidator());
+
+        var exception = Assert.Throws<ValidationException>(
+            () => ArgumentValidation.Validate(cache, typeof(TheInput), new TheInput(), new Dictionary<string, object?>(), null));
+
+        Assert.Contains("no-provider", exception.Message);
+    }
+
+    static ValidatorInstanceCache BuildCache(IValidator validator) =>
+        new(_ => _ == typeof(TheInput) ? validator : null);
+
+    class StubProvider(Dependency dependency) :
+        IServiceProvider
+    {
+        public object? GetService(Type serviceType) =>
+            serviceType == typeof(Dependency) ? dependency : null;
+    }
+
+    record TheInput;
+
+    record Dependency(string Value);
+
+    class ServiceReadingValidator :
+        AbstractValidator<TheInput>
+    {
+        public ServiceReadingValidator() =>
+            RuleFor(_ => _)
+                .Custom((_, context) => context.AddFailure(context.GetRequiredService<Dependency>().Value));
+    }
+
+    class ProviderProbeValidator :
+        AbstractValidator<TheInput>
+    {
+        public ProviderProbeValidator() =>
+            RuleFor(_ => _)
+                .Custom((_, context) =>
+                {
+                    if (context.TryGetServiceProvider(out var provider))
+                    {
+                        context.AddFailure(
+                            provider.GetType().Name);
+                    }
+                    else
+                    {
+                        context.AddFailure(
+                            "no-provider");
+                    }
+                });
+    }
+}


### PR DESCRIPTION
BuildValidationContext now stashes the IServiceProvider (already passed in from IResolveFieldContext.RequestServices) into RootContextData, so validators can resolve request-scoped services — mirroring how UserContext<T>() surfaces the user context.

New IValidationContext extensions:
- TryGetServiceProvider(out) / GetServiceProvider()
- GetRequiredService<T>()